### PR TITLE
feat: add repository/issues/homepage properties to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-plugin-chai-as-promised",
+  "name": "@fintechstudios/eslint-plugin-chai-as-promised",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   ],
   "author": "Dylan Praul",
   "main": "lib/index.js",
+  "bugs": "https://github.com/fintechstudios/eslint-plugin-chai-as-promised/issues",
+  "repository": "https://github.com/fintechstudios/eslint-plugin-chai-as-promised",
+  "homepage": "https://github.com/fintechstudios/eslint-plugin-chai-as-promised",
   "scripts": {
     "test": "mocha",
     "preversion": "npm run test -- --single-run",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "eslint-plugin"
   ],
   "author": "Dylan Praul",
+  "contributors": [],
   "main": "lib/index.js",
   "bugs": "https://github.com/fintechstudios/eslint-plugin-chai-as-promised/issues",
   "repository": "https://github.com/fintechstudios/eslint-plugin-chai-as-promised",
   "homepage": "https://github.com/fintechstudios/eslint-plugin-chai-as-promised",
   "scripts": {
     "test": "mocha",
+    "lint": "eslint .",
     "preversion": "npm run test -- --single-run",
     "postversion": "git push --follow-tags && npm publish --access public"
   },


### PR DESCRIPTION
For discoverability of Github resources from npm page, adds `repository`, `issues`, and `homepage` properties.

Also fixes the `name` in `package-lock.json` and adds the recommended `contributors` property and a `lint` script.