### PR TITLE
Use ES6 features

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,14 @@
     "RuleTester": true
   },
   "rules": {
-    "indent": ["error", 2]
+    "strict": ["error"],
+    "indent": ["error", 2],
+
+    "semi": ["error"],
+    "prefer-const": ["error"],
+    "no-var": ["error"],
+    "prefer-destructuring": ["error"],
+    "object-shorthand": ["error"],
+    "quotes": ["error", "single"]
   }
 }

--- a/lib/rules/no-unhandled-promises.js
+++ b/lib/rules/no-unhandled-promises.js
@@ -1,29 +1,29 @@
 'use strict';
 
-var findInExpressionTree = require('../util/find-in-expression-tree');
-var isNodeChaiCall = require('../util/is-node-chai-call');
-var isNodeChaiAsPromised = require('../util/is-node-chai-as-promised');
-var isNodeNotify = require('../util/is-node-notify');
+const findInExpressionTree = require('../util/find-in-expression-tree');
+const isNodeChaiCall = require('../util/is-node-chai-call');
+const isNodeChaiAsPromised = require('../util/is-node-chai-as-promised');
+const isNodeNotify = require('../util/is-node-notify');
 
 module.exports = {
   meta: {
     docs: {
-      description: "Must handle promises returned from chai-as-promised expressions",
-      category: "Possible Errors",
+      description: 'Must handle promises returned from chai-as-promised expressions',
+      category: 'Possible Errors',
       recommended: true,
     },
     fixable: null,
     schema: [],
   },
-  create: function(context) {
+  create(context) {
     return {
-      ExpressionStatement: function(node) {
-        var found = findInExpressionTree(node.expression, [isNodeChaiCall, isNodeChaiAsPromised, isNodeNotify]);
-        var chaiCall = found[0];
-        var chaiAsPromisedCall = found[1];
-
-        // notify can also be used to alert runner
-        var notifyCall = found[2];
+      ExpressionStatement(node) {
+        const [
+          chaiCall,
+          chaiAsPromisedCall,
+          // notify can also be used to alert runner
+          notifyCall
+        ] = findInExpressionTree(node.expression, [isNodeChaiCall, isNodeChaiAsPromised, isNodeNotify]);
 
         if (!notifyCall && chaiCall && chaiAsPromisedCall) {
           context.report({

--- a/lib/rules/no-unhandled-promises.spec.js
+++ b/lib/rules/no-unhandled-promises.spec.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var rule = require('./no-unhandled-promises');
+const rule = require('./no-unhandled-promises');
 
 function wrapCodeInTestFunction(code) {
   return 'it(\'should test\', async function test() { ' + code + '; })';
 }
 
-var unhandledExpressions = [
+const unhandledExpressions = [
   'expect(promise).to.eventually.deep.equal("foo")',
   'expect(promise).to.eventually.be.true',
   'expect(promise).to.be.fulfilled',

--- a/lib/util/find-in-expression-tree.js
+++ b/lib/util/find-in-expression-tree.js
@@ -8,18 +8,17 @@
  * @return {Array<*>} each index will be the result of the corresponding tests index result
  */
 function findInExpressionTree(startNode, tests) {
-  var node = startNode;
-  var i;
-  var result;
-  var found = [];
-  var numFound = 0;
+  const found = [];
+
+  let node = startNode;
+  let numFound = 0;
 
   while (node) {
-    for (i = 0; i < tests.length; i += 1) {
+    for (let i = 0; i < tests.length; i += 1) {
       if (found[i]) {
         continue;
       }
-      result = tests[i](node);
+      const result = tests[i](node);
       if (result) {
         found[i] = result;
         numFound += 1;

--- a/lib/util/is-node-chai-as-promised.js
+++ b/lib/util/is-node-chai-as-promised.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var chaiAsPromiseProperties = [
+const chaiAsPromiseProperties = [
   'eventually',
   'fulfilled',
   'become',


### PR DESCRIPTION
refactor: use a few es6 features, applying linting rules; also move let closer to scope

Also adds `.eslintignore` (when introspecting on `node_modules` files in IDE, won't complain)

(I was looking to see about offering another rule, but thought I'd submit this one first if this is ok...)