### PR TITLE
feat(no-await-in-condition): new rule to report use of await within chai-as-promised conditions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-node_modules

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,14 @@
     "RuleTester": true
   },
   "rules": {
-    "indent": ["error", 2]
+    "strict": ["error"],
+    "indent": ["error", 2],
+
+    "semi": ["error"],
+    "prefer-const": ["error"],
+    "no-var": ["error"],
+    "prefer-destructuring": ["error"],
+    "object-shorthand": ["error"],
+    "quotes": ["error", "single"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
-    "@fintechstudios/chai-as-promised/no-unhandled-promises": 2
+    "@fintechstudios/chai-as-promised/no-unhandled-promises": 2,
+    "@fintechstudios/chai-as-promised/no-await-in-condition": 2
   }
 }
 ```
@@ -52,4 +53,7 @@ following instead:
 
 ## Supported Rules
 
-* [`no-unhandled-promises`](./docs/rules/no-unhandled-promises.md): Must handle promises returned from chai-as-promised expressions
+* [`no-await-in-condition`](./docs/rules/no-await-in-condition.md): Must not use
+  await within chai-as-promised expressions
+* [`no-unhandled-promises`](./docs/rules/no-unhandled-promises.md): Must handle
+  promises returned from chai-as-promised expressions

--- a/docs/rules/no-await-in-conditions.md
+++ b/docs/rules/no-await-in-conditions.md
@@ -1,0 +1,53 @@
+# Must not use await within chai-as-promised expressions (no-await-in-conditions)
+
+## Rule Details
+
+Chai-as-promised checks against a promise--not its resolved value. While writing up some `Promise`-based code, one might be accuomsted to always adding an `await` when handling the `Promise`. This rule therefore prohibits use of `await` within `chai-as-promised`-style conditions.
+
+Examples of **incorrect** code for this rule:
+
+```js
+it('should ...', async function() {
+  return expect(await promise).to.eventually.deep.equal("foo");
+});
+
+it('should ...', async function() {
+  await expect(await promise).to.eventually.deep.equal("foo");
+});
+
+it('should ...', async function() {
+  return expect(await promise).to.be.rejectedWith(Error);
+});
+
+it('should ...', async function() {
+  return (await promise).should.eventually.deep.equal("foo");
+});
+
+it('should ...', async function() {
+  return assert.isFulfilled(await promise, "optional message");
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it('should ...', async function() {
+  return expect(promise).to.eventually.deep.equal("foo");
+});
+
+it('should ...', async function() {
+  await expect(promise).to.eventually.deep.equal("foo");
+});
+
+it('should ...', async function() {
+  return expect(promise).to.be.rejectedWith(Error);
+});
+
+it('should ...', async function() {
+  return promise.should.eventually.deep.equal("foo");
+});
+
+it('should ...', async function() {
+  return assert.isFulfilled(promise, "optional message");
+});
+```

--- a/docs/rules/no-unhandled-promises.md
+++ b/docs/rules/no-unhandled-promises.md
@@ -1,9 +1,8 @@
 # Must handle promises returned from chai-as-promised expressions (no-unhandled-promises)
 
-
 ## Rule Details
 
-Chai-as-promised makes chai calls return promises. These can easily be fogotten
+Chai-as-promised makes chai calls return promises. These can easily be forgotten
 about, leading to unhandled promises in your test suite. This rule checks for those and
 enforces using return or await.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const noAwaitInCondition = require('./rules/no-await-in-condition');
 const noUnhandledPromisesRules = require('./rules/no-unhandled-promises');
 
 module.exports = {
@@ -7,11 +8,13 @@ module.exports = {
     recommended: {
       plugins: ['@fintechstudios/chai-as-promised'],
       rules: {
+        '@fintechstudios/chai-as-promised/no-await-in-condition': 'error',
         '@fintechstudios/chai-as-promised/no-unhandled-promises': 'error'
       }
     }
   },
   rules: {
+    'no-await-in-condition': noAwaitInCondition,
     'no-unhandled-promises': noUnhandledPromisesRules,
   },
 };

--- a/lib/rules/no-await-in-condition.js
+++ b/lib/rules/no-await-in-condition.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const esquery = require('esquery');
+
+const findInExpressionTree = require('../util/find-in-expression-tree');
+const isNodeChaiCall = require('../util/is-node-chai-call');
+const isNodeChaiAsPromised = require('../util/is-node-chai-as-promised');
+
+function checkHasAwait (context, node) {
+  const [
+    chaiCall,
+    chaiAsPromisedCall
+  ] = findInExpressionTree(node, [
+    isNodeChaiCall, isNodeChaiAsPromised
+  ]);
+
+  if (chaiAsPromisedCall &&
+    chaiCall && esquery(chaiCall.parent, '.arguments[type="AwaitExpression"]')
+  ) {
+    context.report({
+      node: chaiAsPromisedCall,
+      message: 'Uses of chai-as-promised must not occur with an inner await',
+    });
+    return true;
+  }
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Must not use await within chai-as-promised expressions',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+  },
+  create(context) {
+    return {
+      ExpressionStatement(node) {
+        checkHasAwait(context, node.expression);
+      },
+      ReturnStatement(node) {
+        checkHasAwait(context, node.argument);
+      },
+      AwaitExpression(node) {
+        checkHasAwait(context, node.argument);
+      },
+      [
+      // Promise.all([...])
+      'CallExpression' +
+        '[callee.type="MemberExpression"]' +
+          '[callee.object.name="Promise"]' +
+            '[callee.object.type="Identifier"]' +
+          '[callee.property.name="all"]' +
+            '[callee.property.type="Identifier"]'
+      ](node) {
+        const [arrayExpression] = esquery(node, '.arguments[type="ArrayExpression"]');
+        arrayExpression.elements.some((element) => {
+          return checkHasAwait(context, element);
+        });
+      }
+    };
+  }
+};

--- a/lib/rules/no-await-in-condition.js
+++ b/lib/rules/no-await-in-condition.js
@@ -23,6 +23,7 @@ function checkHasAwait (context, node) {
     });
     return true;
   }
+  return false;
 }
 
 module.exports = {

--- a/lib/rules/no-await-in-condition.spec.js
+++ b/lib/rules/no-await-in-condition.spec.js
@@ -49,15 +49,9 @@ ruleTester.run('no-await-in-condition', rule, {
 
   invalid: [].concat(
     // No matter the wrapping, we don't want `await` permitted inside
-    innerAwaitExpressions.map(function (code) {
-      return 'return ' + code;
-    }),
-    innerAwaitExpressions.map(function (code) {
-      return 'await ' + code;
-    }),
-    innerAwaitExpressions.map(function (code) {
-      return code + '.notify(done)';
-    }),
+    innerAwaitExpressions.map((code) => `return ${code}`),
+    innerAwaitExpressions.map((code) => `await ${code}`),
+    innerAwaitExpressions.map((code) => `${code}.notify(done)`),
     [
       'await Promise.all([' +
       innerAwaitExpressions.reduce(function(out, expression) {

--- a/lib/rules/no-await-in-condition.spec.js
+++ b/lib/rules/no-await-in-condition.spec.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const rule = require('./no-await-in-condition');
+const wrapCodeInTestFunction = require('../../test/wrapCodeInTestFunction');
+
+const innerAwaitExpressions = [
+  'expect(await promise).to.eventually.deep.equal("foo")',
+  'expect(await promise).to.eventually.be.true',
+  'expect(await promise).to.be.fulfilled',
+  'expect(await promise).to.become("foo")',
+  'expect(await promise).to.be.rejected',
+  'expect(await promise).to.be.rejectedWith(Error)',
+  '(await promise).should.eventually.deep.equal("foo")',
+  '(await promise).should.eventually.be.true',
+  '(await promise).should.be.fulfilled',
+  '(await promise).should.become("foo")',
+  '(await promise).should.be.rejected',
+  '(await promise).should.be.rejectedWith(Error)',
+  'assert.isFulfilled(await promise, "optional message")',
+  'assert.becomes(await promise, "foo", "optional message")',
+  'assert.doesNotBecome(await promise, "foo", "optional message")',
+  'assert.isRejected(await promise, Error, "optional message")',
+  'assert.isRejected(await promise, /error message regex matcher/, "optional message")',
+  'assert.isRejected(await promise, "substring to search error message for", "optional message")',
+];
+
+ruleTester.run('no-await-in-condition', rule, {
+  valid: [].concat(
+    [
+      // regular chai calls that shouldn't be false-positive
+      'expect(promise).to.be.true',
+      'expect(promise).to.be.a(\'string\')',
+      'expect(promise).to.equal(\'bar\')',
+      'expect(promise).to.have.lengthOf(3)',
+      'expect(promise).to.have.property(\'flavors\').with.lengthOf(3)',
+      'promise.should.be.a(\'string\')',
+      'promise.should.equal(\'bar\')',
+      'promise.should.have.lengthOf(3)',
+      'promise.should.have.property(\'flavors\').with.lengthOf(3)',
+      'assert.typeOf(promise, \'string\')',
+      'assert.equal(promise, \'bar\')',
+      'assert.lengthOf(promise, 3)',
+      'assert.property(promise, \'flavors\')',
+      'assert.lengthOf(promise.flavors, 3)'
+    ]
+  ).map(function (code) {
+    return wrapCodeInTestFunction(code);
+  }),
+
+  invalid: [].concat(
+    // No matter the wrapping, we don't want `await` permitted inside
+    innerAwaitExpressions.map(function (code) {
+      return 'return ' + code;
+    }),
+    innerAwaitExpressions.map(function (code) {
+      return 'await ' + code;
+    }),
+    innerAwaitExpressions.map(function (code) {
+      return code + '.notify(done)';
+    }),
+    [
+      'await Promise.all([' +
+      innerAwaitExpressions.reduce(function(out, expression) {
+        return out + '\n  ' + expression + ',';
+      }, '') +
+      '\n]);'
+    ],
+    innerAwaitExpressions
+  ).map(function (code) {
+    return {
+      code: wrapCodeInTestFunction(code),
+      errors: [{
+        message: 'Uses of chai-as-promised must not occur with an inner await',
+        type: 'Identifier',
+      }],
+    };
+  })
+});

--- a/lib/rules/no-await-in-condition.spec.js
+++ b/lib/rules/no-await-in-condition.spec.js
@@ -54,9 +54,7 @@ ruleTester.run('no-await-in-condition', rule, {
     innerAwaitExpressions.map((code) => `${code}.notify(done)`),
     [
       'await Promise.all([' +
-      innerAwaitExpressions.reduce(function(out, expression) {
-        return out + '\n  ' + expression + ',';
-      }, '') +
+      innerAwaitExpressions.reduce((out, expression) => `${out}\n ${expression},`, '') +
       '\n]);'
     ],
     innerAwaitExpressions

--- a/lib/rules/no-unhandled-promises.js
+++ b/lib/rules/no-unhandled-promises.js
@@ -1,29 +1,29 @@
 'use strict';
 
-var findInExpressionTree = require('../util/find-in-expression-tree');
-var isNodeChaiCall = require('../util/is-node-chai-call');
-var isNodeChaiAsPromised = require('../util/is-node-chai-as-promised');
-var isNodeNotify = require('../util/is-node-notify');
+const findInExpressionTree = require('../util/find-in-expression-tree');
+const isNodeChaiCall = require('../util/is-node-chai-call');
+const isNodeChaiAsPromised = require('../util/is-node-chai-as-promised');
+const isNodeNotify = require('../util/is-node-notify');
 
 module.exports = {
   meta: {
     docs: {
-      description: "Must handle promises returned from chai-as-promised expressions",
-      category: "Possible Errors",
+      description: 'Must handle promises returned from chai-as-promised expressions',
+      category: 'Possible Errors',
       recommended: true,
     },
     fixable: null,
     schema: [],
   },
-  create: function(context) {
+  create(context) {
     return {
-      ExpressionStatement: function(node) {
-        var found = findInExpressionTree(node.expression, [isNodeChaiCall, isNodeChaiAsPromised, isNodeNotify]);
-        var chaiCall = found[0];
-        var chaiAsPromisedCall = found[1];
-
-        // notify can also be used to alert runner
-        var notifyCall = found[2];
+      ExpressionStatement(node) {
+        const [
+          chaiCall,
+          chaiAsPromisedCall,
+          // notify can also be used to alert runner
+          notifyCall
+        ] = findInExpressionTree(node.expression, [isNodeChaiCall, isNodeChaiAsPromised, isNodeNotify]);
 
         if (!notifyCall && chaiCall && chaiAsPromisedCall) {
           context.report({

--- a/lib/rules/no-unhandled-promises.spec.js
+++ b/lib/rules/no-unhandled-promises.spec.js
@@ -1,10 +1,7 @@
 'use strict';
 
 const rule = require('./no-unhandled-promises');
-
-function wrapCodeInTestFunction(code) {
-  return 'it(\'should test\', async function test() { ' + code + '; })';
-}
+const wrapCodeInTestFunction = require('../../test/wrapCodeInTestFunction');
 
 const unhandledExpressions = [
   'expect(promise).to.eventually.deep.equal("foo")',
@@ -47,7 +44,7 @@ ruleTester.run('no-unhandled-promises', rule, {
       '\n]);'
     ],
     [
-      // regular chai calls that shouldn't false-positive
+      // regular chai calls that shouldn't be false-positive
       'expect(promise).to.be.true',
       'expect(promise).to.be.a(\'string\')',
       'expect(promise).to.equal(\'bar\')',

--- a/lib/rules/no-unhandled-promises.spec.js
+++ b/lib/rules/no-unhandled-promises.spec.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var rule = require('./no-unhandled-promises');
+const rule = require('./no-unhandled-promises');
 
 function wrapCodeInTestFunction(code) {
   return 'it(\'should test\', async function test() { ' + code + '; })';
 }
 
-var unhandledExpressions = [
+const unhandledExpressions = [
   'expect(promise).to.eventually.deep.equal("foo")',
   'expect(promise).to.eventually.be.true',
   'expect(promise).to.be.fulfilled',

--- a/lib/util/find-in-expression-tree.js
+++ b/lib/util/find-in-expression-tree.js
@@ -8,18 +8,17 @@
  * @return {Array<*>} each index will be the result of the corresponding tests index result
  */
 function findInExpressionTree(startNode, tests) {
-  var node = startNode;
-  var i;
-  var result;
-  var found = [];
-  var numFound = 0;
+  const found = [];
+
+  let node = startNode;
+  let numFound = 0;
 
   while (node) {
-    for (i = 0; i < tests.length; i += 1) {
+    for (let i = 0; i < tests.length; i += 1) {
       if (found[i]) {
         continue;
       }
-      result = tests[i](node);
+      const result = tests[i](node);
       if (result) {
         found[i] = result;
         numFound += 1;

--- a/lib/util/is-node-chai-as-promised.js
+++ b/lib/util/is-node-chai-as-promised.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var chaiAsPromiseProperties = [
+const chaiAsPromiseProperties = [
   'eventually',
   'fulfilled',
   'become',

--- a/test/wrapCodeInTestFunction.js
+++ b/test/wrapCodeInTestFunction.js
@@ -1,5 +1,7 @@
 'use strict';
 
-module.exports = function wrapCodeInTestFunction(code) {
-  return 'it(\'should test\', async function test() { ' + code + '; })';
+function wrapCodeInTestFunction(code) {
+  return `it('should test', async function test() { ${code}; })`;
 };
+
+module.exports = wrapCodeInTestFunction;

--- a/test/wrapCodeInTestFunction.js
+++ b/test/wrapCodeInTestFunction.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function wrapCodeInTestFunction(code) {
+  return 'it(\'should test\', async function test() { ' + code + '; })';
+};

--- a/test/wrapCodeInTestFunction.js
+++ b/test/wrapCodeInTestFunction.js
@@ -2,6 +2,6 @@
 
 function wrapCodeInTestFunction(code) {
   return `it('should test', async function test() { ${code}; })`;
-};
+}
 
 module.exports = wrapCodeInTestFunction;


### PR DESCRIPTION
Builds on #9.

feat(no-await-in-condition): new rule to report use of `await` within chai-as-promised conditions

BREAKING CHANGE:

Adds new rule to `recommended`