### PR TITLE
test(no-await-in-condition): examples where await is ok

### DIFF
--- a/docs/rules/no-await-in-condition.md
+++ b/docs/rules/no-await-in-condition.md
@@ -50,4 +50,9 @@ it('should ...', async function() {
 it('should ...', async function() {
   return assert.isFulfilled(promise, "optional message");
 });
+
+it('should ...', async function() {
+  // This is ok since the chain is not a `chai-as-promised` one
+  return expect(await promise).to.be.true;
+});
 ```

--- a/lib/rules/no-await-in-condition.spec.js
+++ b/lib/rules/no-await-in-condition.spec.js
@@ -33,16 +33,18 @@ ruleTester.run('no-await-in-condition', rule, {
       'expect(promise).to.equal(\'bar\')',
       'expect(promise).to.have.lengthOf(3)',
       'expect(promise).to.have.property(\'flavors\').with.lengthOf(3)',
+      'expect(await promise).to.be.true',
       'promise.should.be.a(\'string\')',
       'promise.should.equal(\'bar\')',
       'promise.should.have.lengthOf(3)',
       'promise.should.have.property(\'flavors\').with.lengthOf(3)',
+      '(await promise).should.be.a(\'string\')',
       'assert.typeOf(promise, \'string\')',
       'assert.equal(promise, \'bar\')',
       'assert.lengthOf(promise, 3)',
       'assert.property(promise, \'flavors\')',
       'assert.lengthOf(promise.flavors, 3)',
-      'expect(await promise).to.be.true'
+      'assert.equal(await promise, \'bar\')'
     ]
   ).map(function (code) {
     return wrapCodeInTestFunction(code);

--- a/lib/rules/no-await-in-condition.spec.js
+++ b/lib/rules/no-await-in-condition.spec.js
@@ -41,7 +41,8 @@ ruleTester.run('no-await-in-condition', rule, {
       'assert.equal(promise, \'bar\')',
       'assert.lengthOf(promise, 3)',
       'assert.property(promise, \'flavors\')',
-      'assert.lengthOf(promise.flavors, 3)'
+      'assert.lengthOf(promise.flavors, 3)',
+      'expect(await promise).to.be.true'
     ]
   ).map(function (code) {
     return wrapCodeInTestFunction(code);


### PR DESCRIPTION
- Add example where `await` is ok in the condition (when not part of a `chai-as-promised` chain)

Sorry, with a fresh look at the just merged PR, I realized there was probably this one type of documentation/test at least that should be added for clarification.