### PR TITLE
fix(no-await-in-condition): better detection of await expression

### DIFF
--- a/lib/rules/no-await-in-condition.js
+++ b/lib/rules/no-await-in-condition.js
@@ -14,9 +14,10 @@ function checkHasAwait (context, node) {
     isNodeChaiCall, isNodeChaiAsPromised
   ]);
 
-  if (chaiAsPromisedCall &&
-    chaiCall && esquery(chaiCall.parent, '.arguments[type="AwaitExpression"]')
-  ) {
+  if (chaiAsPromisedCall && chaiCall && esquery(
+    chaiCall.parent,
+    ':matches(.arguments[type="AwaitExpression"], .object[type="AwaitExpression"])'
+  ).length) {
     context.report({
       node: chaiAsPromisedCall,
       message: 'Uses of chai-as-promised must not occur with an inner await',

--- a/lib/rules/no-await-in-condition.spec.js
+++ b/lib/rules/no-await-in-condition.spec.js
@@ -44,7 +44,9 @@ ruleTester.run('no-await-in-condition', rule, {
       'assert.lengthOf(promise, 3)',
       'assert.property(promise, \'flavors\')',
       'assert.lengthOf(promise.flavors, 3)',
-      'assert.equal(await promise, \'bar\')'
+      'assert.equal(await promise, \'bar\')',
+      `expect(func()).to.be.rejectedWith(Error, 'No good!')
+      `
     ]
   ).map(function (code) {
     return wrapCodeInTestFunction(code);


### PR DESCRIPTION
When applying to some more sizable real world repos (as I'm afraid I should have done earlier), I found there was a bug in detecting `await` expression (by not checking `length` it was always matching), and fixing this bug surfaced another problem that the `await` expression needed to be checked in another context.

I've confirmed my real world tests (in 3 other repos) have no false positives now (as well as the test added herein).

Apologies for not checking this earlier!