### PR TITLE
fix(no-await-in-condition): avoid error on Promise.all without array

### DIFF
--- a/lib/rules/no-await-in-condition.js
+++ b/lib/rules/no-await-in-condition.js
@@ -6,6 +6,13 @@ const findInExpressionTree = require('../util/find-in-expression-tree');
 const isNodeChaiCall = require('../util/is-node-chai-call');
 const isNodeChaiAsPromised = require('../util/is-node-chai-as-promised');
 
+const PromiseAllSelector = 'CallExpression' +
+  '[callee.type="MemberExpression"]' +
+    '[callee.object.name="Promise"]' +
+      '[callee.object.type="Identifier"]' +
+    '[callee.property.name="all"]' +
+      '[callee.property.type="Identifier"]';
+
 function checkHasAwait (context, node) {
   const [
     chaiCall,
@@ -17,6 +24,9 @@ function checkHasAwait (context, node) {
   if (chaiAsPromisedCall && chaiCall && esquery(
     chaiCall.parent,
     ':matches(.arguments[type="AwaitExpression"], .object[type="AwaitExpression"])'
+  ).length && !esquery(
+    chaiCall.parent.parent,
+    PromiseAllSelector
   ).length) {
     context.report({
       node: chaiAsPromisedCall,
@@ -48,16 +58,11 @@ module.exports = {
       AwaitExpression(node) {
         checkHasAwait(context, node.argument);
       },
-      [
-      // Promise.all([...])
-      'CallExpression' +
-        '[callee.type="MemberExpression"]' +
-          '[callee.object.name="Promise"]' +
-            '[callee.object.type="Identifier"]' +
-          '[callee.property.name="all"]' +
-            '[callee.property.type="Identifier"]'
-      ](node) {
+      [PromiseAllSelector](node) {
         const [arrayExpression] = esquery(node, '.arguments[type="ArrayExpression"]');
+        if (!arrayExpression) {
+          return;
+        }
         arrayExpression.elements.some((element) => {
           return checkHasAwait(context, element);
         });

--- a/lib/rules/no-await-in-condition.spec.js
+++ b/lib/rules/no-await-in-condition.spec.js
@@ -46,7 +46,9 @@ ruleTester.run('no-await-in-condition', rule, {
       'assert.lengthOf(promise.flavors, 3)',
       'assert.equal(await promise, \'bar\')',
       `expect(func()).to.be.rejectedWith(Error, 'No good!')
-      `
+      `,
+      'expect(Promise.all(arr)).to.eventually.be.true',
+      'expect(Promise.all(await prom)).to.be.fulfilled'
     ]
   ).map(function (code) {
     return wrapCodeInTestFunction(code);


### PR DESCRIPTION
I regrettably had another bug in `no-await-in-condition`.

fix(no-await-in-condition): Avoid erring upon encountering `Promise.all` without array