### PR TITLE
feat: add `meta.type`

### DIFF
--- a/lib/rules/no-await-in-condition.js
+++ b/lib/rules/no-await-in-condition.js
@@ -39,6 +39,7 @@ function checkHasAwait (context, node) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Must not use await within chai-as-promised expressions',
       category: 'Possible Errors',

--- a/lib/rules/no-unhandled-promises.js
+++ b/lib/rules/no-unhandled-promises.js
@@ -7,6 +7,7 @@ const isNodeNotify = require('../util/is-node-notify');
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Must handle promises returned from chai-as-promised expressions',
       category: 'Possible Errors',


### PR DESCRIPTION
Though the rules are not fixable (so as to be able to use eslint's `--fix-type` with `meta.type`), `meta.type` can still be useful to formatters (e.g., my [eslint-formatter-badger](https://github.com/brettz9/eslint-formatter-badger) to utilize information on the type of rule).

Note that although any linting rule could have some debate about whether a particular usage was always a "problem" or "suggestion", I think it generally applies for these rules (the other categories being "suggestion" or "layout").